### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.0.1] - 2026-02-19
 
 ### Fixed
 - **Refresh status**: The Refresh Status button and `evcnet.refresh_status` service now call the portal GetStatus API before refreshing data; previously they only triggered a coordinator refresh and did not request fresh status from the charger.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **Refresh status**: The Refresh Status button and `evcnet.refresh_status` service now call the portal GetStatus API before refreshing data; previously they only triggered a coordinator refresh and did not request fresh status from the charger.
+- Action services (refresh_status, soft_reset, hard_reset, etc.) are now registered with proper async handlers so the service calls are correctly awaited (fixes "coroutine was never awaited" warning in logs).
+
+### Changed
+- Refresh Status button now uses the same base class and execution flow as the other action buttons (API call, settle delay, coordinator refresh).
+
 ## [1.0.0] - 2026-02-12
 
 This release introduces multi-channel support and is versioned 1.0.0 to reflect the impact for users with multi-connector charging stations.

--- a/custom_components/evcnet/api.py
+++ b/custom_components/evcnet/api.py
@@ -370,6 +370,22 @@ class EvcNetApiClient:
 
         return await self._make_ajax_request(requests_payload)
 
+    async def get_status(self, recharge_spot_id: str) -> dict[str, Any]:
+        """Request fresh status from the charging spot (GetStatus action)."""
+        requests_payload = {
+            "0": {
+                "handler": "\\LMS\\EV\\AsyncServices\\RechargeSpotsAsyncService",
+                "method": "action",
+                "params": {
+                    "action": "GetStatus",
+                    "rechargeSpotId": recharge_spot_id,
+                    "clickedButtonId": 1,
+                },
+            }
+        }
+
+        return await self._make_ajax_request(requests_payload)
+
     async def soft_reset(self, recharge_spot_id: str, channel: str) -> dict[str, Any]:
         """Perform a soft reset on a charging station."""
         requests_payload = {

--- a/custom_components/evcnet/manifest.json
+++ b/custom_components/evcnet/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Platzii/homeassistant-evcnet/issues",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/custom_components/evcnet/services.yaml
+++ b/custom_components/evcnet/services.yaml
@@ -1,11 +1,3 @@
-refresh_status:
-  name: Refresh status
-  description: Manually trigger an immediate status update from the portal
-  target:
-    entity:
-      domain: button
-      integration: evcnet
-
 start_charging:
   name: Start charging
   description: Start a charging session with an optional RFID card ID
@@ -24,6 +16,14 @@ start_charging:
 stop_charging:
   name: Stop charging
   description: Stop the current charging session
+  target:
+    entity:
+      domain: switch
+      integration: evcnet
+
+refresh_status:
+  name: Refresh status
+  description: Manually trigger an immediate status update from the portal
   target:
     entity:
       domain: switch


### PR DESCRIPTION
### Fixed
- **Refresh status**: The Refresh Status button and `evcnet.refresh_status` service now call the portal GetStatus API before refreshing data; previously they only triggered a coordinator refresh and did not request fresh status from the charger.
- Action services (refresh_status, soft_reset, hard_reset, etc.) are now registered with proper async handlers so the service calls are correctly awaited (fixes "coroutine was never awaited" warning in logs).

### Changed
- Refresh Status button now uses the same base class and execution flow as the other action buttons (API call, settle delay, coordinator refresh).